### PR TITLE
fix: outgoing only working with auto-relay

### DIFF
--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -184,7 +184,7 @@ export function cliOptions(): MailDevOptions {
     hidePIPELINING: (config?.hideExtensions ?? []).includes("PIPELINING"),
     hideSMTPUTF8: (config?.hideExtensions ?? []).includes("SMTPUTF8"),
     outgoing:
-      config?.autoRelay || config?.autoRelayRules
+      (config?.autoRelay || config?.autoRelayRules || config?.outgoingHost)
         ? {
             host: config?.outgoingHost,
             port: config?.outgoingPort,

--- a/src/lib/outgoing.ts
+++ b/src/lib/outgoing.ts
@@ -176,7 +176,7 @@ function relayMail(outgoing: Outgoing, emailObject, emailStream, isAutoRelay, do
         createClient(outgoing);
 
         if (err) {
-          logger.error("Mail Delivery Error: ", err);
+          logger.error("Mail Delivery Error: ", err, { sender, recipients });
           return done(err);
         }
 

--- a/src/lib/outgoing.ts
+++ b/src/lib/outgoing.ts
@@ -163,7 +163,8 @@ function relayMail(outgoing: Outgoing, emailObject, emailStream, isAutoRelay, do
       return done(err);
     }
 
-    const emailFrom = emailObject.envelope.from || emailObject.from;
+    let emailFrom = emailObject.envelope.from || emailObject.from;
+    if (Array.isArray(emailFrom)) emailFrom = emailFrom.shift();
     const sender = getAddressFromAddressObject(emailFrom);
     outgoing.client.send(
       {

--- a/src/lib/outgoing.ts
+++ b/src/lib/outgoing.ts
@@ -145,7 +145,9 @@ function relayMail(outgoing: Outgoing, emailObject, emailStream, isAutoRelay, do
     emailObject.envelope.to = [{ address: outgoing.autoRelayAddress, args: false }];
   }
 
-  let recipients = emailObject.envelope.to.map(getAddressFromAddressObject);
+  let recipients = emailObject.envelope.to?.length
+    ? emailObject.envelope.to.map(getAddressFromAddressObject)
+    : emailObject.to.map(getAddressFromAddressObject);
   if (isAutoRelay && outgoing.autoRelayRules) {
     recipients = getAutoRelayableRecipients(recipients, outgoing.autoRelayRules);
   }
@@ -161,7 +163,8 @@ function relayMail(outgoing: Outgoing, emailObject, emailStream, isAutoRelay, do
       return done(err);
     }
 
-    const sender = getAddressFromAddressObject(emailObject.envelope.from);
+    const emailFrom = emailObject.envelope.from || emailObject.from;
+    const sender = getAddressFromAddressObject(emailFrom);
     outgoing.client.send(
       {
         from: sender,

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -122,7 +122,7 @@ export function routes(app, mailserver: MailServer, basePathname: string) {
   });
 
   // Relay the email
-  router.post("/email/:id/relay/:relayTo?", function (req, res) {
+  router.post("/email/:id/relay{/:relayTo}", function (req, res) {
     mailserver
       .getEmail(req.params.id)
       .then((mail) => {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -122,7 +122,7 @@ export function routes(app, mailserver: MailServer, basePathname: string) {
   });
 
   // Relay the email
-  router.post("/email/:id/relay{/:relayTo}", function (req, res) {
+  router.post("/email/:id/relay/:relayTo?", function (req, res) {
     mailserver
       .getEmail(req.params.id)
       .then((mail) => {


### PR DESCRIPTION
The options only sets up outgoing if an auto-relay option is present. As per the readme, it should be enabled if the outgoing options are present. Of the outgoing options, host is definitely always required.