### PR TITLE
Fix auth module import

### DIFF
--- a/src/lib/web.ts
+++ b/src/lib/web.ts
@@ -5,6 +5,7 @@
  */
 import { MailServer } from "./mailserver";
 import { routes } from "./routes";
+import { auth } from "./auth";
 
 const express = require("express");
 const cors = require("cors");
@@ -12,7 +13,6 @@ const fs = require("fs");
 const http = require("http");
 const https = require("https");
 const socketio = require("socket.io");
-const auth = require("./auth");
 const logger = require("./logger");
 const path = require("path");
 


### PR DESCRIPTION
This MR fixes an auth module import that was causing an issue when starting MailDev with basic auth enabled:

```
~ podman run -e MAILDEV_WEB_USER=admin -e MAILDEV_WEB_PASS=password -it timshel/maildev                        
MailDev using directory /tmp/maildev
/home/node/dist/lib/web.js:33
            app.use(auth((_d = options === null || options === void 0 ? void 0 : options.auth) === null || _d === void 0 ? void 0 : _d.user, (_e = options === null || options === void 0 ? void 0 : options.auth) === null || _e === void 0 ? void 0 : _e.pass));
                    ^

TypeError: auth is not a function
    at new Web (/home/node/dist/lib/web.js:33:21)
    at new MailDev (/home/node/dist/index.js:22:24)
    at Object.<anonymous> (/home/node/bin/maildev:12:17)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.19.6
```