### PR TITLE
Performance and sync

### DIFF
--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -150,8 +150,8 @@ export function routes(app, mailserver: MailServer, basePathname: string) {
     res.status(200).json(true);
   });
 
-  router.get("/reloadMailsFromDirectory", function (req, res) {
-    mailserver.loadMailsFromDirectory();
+  router.get("/reloadMailsFromDirectory", async function (req, res) {
+    await mailserver.loadMailsFromDirectory();
     res.status(200).json(true);
   });
   app.use(basePathname, router);


### PR DESCRIPTION
This MR:

1) Adds a synchronization guard for `/reloadMailsFromDirectory`, all concurrent requests will be discarded.
2) Sends the correct events to the frontend so the user can see emails disappear one by one when a reload is triggered, instead of rebuilding the full list.
3) Refactors `loadMailsFromDirectory()` to load emails in parallel batches, significantly reducing memory usage. With 1000 emails, it now uses about **70 MB instead of 700 MB** at startup.